### PR TITLE
Enable docker deploys for dsmr2mqtt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "async-channel"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -33,9 +33,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "bytes"
@@ -51,9 +51,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "dsmr5"
 version = "0.1.0"
-source = "git+https://github.com/NULLx76/dsmr5#f34aca9c185956cf8f0912f893b5c107ccb97882"
+source = "git+https://github.com/NULLx76/dsmr5#c673fbaed243a5ade08dfa7768d78f1608bd85bd"
 dependencies = [
  "crc16",
 ]
@@ -109,24 +109,24 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes",
  "fnv",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if",
 ]
@@ -159,9 +159,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -174,15 +174,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -198,15 +198,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -217,11 +217,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi",
 ]
 
@@ -255,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "parking_lot"
@@ -286,21 +285,21 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pollster"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0c427c464eaca5923b642b3b346792b9c98edd91026aa6a753435e42d2a07b"
+checksum = "bb20dcc30536a1508e75d47dd0e399bb2fe7354dcf35cda9127f2bf1ed92e30e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -316,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -358,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64",
  "log",
@@ -377,9 +376,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -429,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -443,17 +442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
-name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,9 +449,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -481,18 +469,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -501,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes",
@@ -521,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -543,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "untrusted"
@@ -555,9 +543,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -565,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -580,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -590,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -603,15 +591,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ rumqttc = "0.5"
 
 [profile.release]
 lto = true
+
+
+[[bin]]
+path = "src/main.rs"
+name = "dsmr"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# We use the latest Rust stable release as base image
+FROM rustlang/rust:nightly-slim AS builder
+# Let's switch our working directory to `app` (equivalent to `cd app`)
+# The `app` folder will be created for us by Docker in case it does not
+# exist already.
+WORKDIR /app
+
+# Run deps first. If nothing changes, this step will be cached by docker
+COPY Cargo.* .
+RUN cargo fetch
+
+# Copy all files from our working environment to our Docker image
+COPY . .
+# Let's build our binary!
+# We'll use the release profile to make it faaaast
+RUN cargo build --release
+
+FROM debian:buster-slim AS runtime
+WORKDIR /app
+# Install OpenSSL - it is dynamically linked by some of our dependencies
+# RUN apt-get update -y \
+#     && apt-get install -y --no-install-recommends openssl \
+#     # Clean up
+#     && apt-get autoremove -y \
+#     && apt-get clean -y \
+#     && rm -rf /var/lib/apt/lists/*
+
+# ENV APP_LISTEN=0.0.0.0:8080
+# ENV APP_ENVIRONMENT production
+
+
+COPY --from=builder /app/target/release/dsmr dsmr
+ENTRYPOINT ["./dsmr"]

--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ The following variables can be configured
 | MQTT_TOPIC  | The topic prefix           | `dsmr`                   |
 | MQTT_QOS    | The MQTT QOS               | `0`                      |
 | SERIAL_PORT | The port to listen to      | `/dev/ttyUSB1`           |
+
+# Docker builds
+
+To build for all platforms, use
+
+```
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 \
+    --push \
+    -t alexnederlof/dsmr2mqtt .
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # DSMR to MQTT
-Reads out a dutch smart meter using the DSMRv5 protocol 
+
+Reads out a dutch smart meter using the DSMRv5 protocol
 and publishes some of the stats out to an mqtt broker.
 
 ## DSMRv5 Parser
+
 For parsing the data telegrams I use a modified version of the `dsmr5` crate,
 you can view its source [here](https://github.com/NULLx76/dsmr5)
+
+# Config
+
+The following variables can be configured
+
+| name        | meaning                    | default                  |
+| ----------- | -------------------------- | ------------------------ |
+| MQTT_HOST   | The address of your server | `tcp://10.10.10.13:1883` |
+| MQTT_TOPIC  | The topic prefix           | `dsmr`                   |
+| MQTT_QOS    | The MQTT QOS               | `0`                      |
+| SERIAL_PORT | The port to listen to      | `/dev/ttyUSB1`           |

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ you can view its source [here](https://github.com/NULLx76/dsmr5)
 
 The following variables can be configured
 
-| name        | meaning                    | default                  |
-| ----------- | -------------------------- | ------------------------ |
-| MQTT_HOST   | The address of your server | `tcp://10.10.10.13:1883` |
-| MQTT_TOPIC  | The topic prefix           | `dsmr`                   |
-| MQTT_QOS    | The MQTT QOS               | `0`                      |
-| SERIAL_PORT | The port to listen to      | `/dev/ttyUSB1`           |
+| name        | meaning                                      | default        |
+| ----------- | -------------------------------------------- | -------------- |
+| MQTT_HOST   | The address of your MQTT server (IP or FQDN) | `::1`          |
+| MQTT_TOPIC  | The topic prefix                             | `dsmr`         |
+| MQTT_QOS    | The MQTT QOS                                 | `0`            |
+| SERIAL_PORT | The port to listen to                        | `/dev/ttyUSB1` |
 
 # Docker builds
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,3 @@
-use std::backtrace::Backtrace;
-
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -7,8 +5,7 @@ pub enum MyError {
     #[error("serial connection failed")]
     SerialError {
         #[from]
-        source: serial::Error,
-        backtrace: Backtrace,
+        source: serial::Error
     },
 
     #[error("parsing dsmr failed")]
@@ -17,8 +14,7 @@ pub enum MyError {
     #[error("mqtt error occured")]
     MqttError {
         #[from]
-        source: rumqttc::ClientError,
-        backtrace: Backtrace,
+        source: rumqttc::ClientError
     },
 
     #[error("serial readed reached unexpected end")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,3 @@
-#![feature(never_type)]
-#![feature(iter_map_while)]
-#![feature(backtrace)]
-
 mod error;
 mod mqtt;
 mod report;
@@ -9,9 +5,9 @@ use error::MyError;
 use report::*;
 
 use rumqttc::{AsyncClient, MqttOptions, Transport};
-use serial::core::SerialDevice;
+use serial::SerialPort;
 use std::{env, io::Read, time::Duration};
-use tokio::{io, select, task::JoinHandle};
+use tokio::{select, task::JoinHandle};
 
 struct Config {
     pub mqtt_host: String,
@@ -56,7 +52,7 @@ async fn main() -> ! {
     loop {
         let (mut client, mut eventloop) = AsyncClient::new(mqttoptions.clone(), 12);
 
-        let eventloop: JoinHandle<Result<!, io::Error>> = tokio::spawn(async move {
+        let eventloop: JoinHandle<_> = tokio::spawn(async move {
             loop {
                 let _event = eventloop.poll().await.unwrap();
             }
@@ -81,11 +77,19 @@ async fn main() -> ! {
     }
 }
 
-async fn run(cfg: &Config, mut client: &mut AsyncClient) -> Result<!, MyError> {
+async fn run(cfg: &Config, mut client: &mut AsyncClient) -> Result<(), MyError> {
     // Open Serial
-    let mut port = serial::open(cfg.serial_port.as_str())?;
-    port.set_timeout(Duration::from_secs(1))?;
-    let reader = dsmr5::Reader::new(port.bytes().map_while(Result::ok));
+    let mut port = serial::open("/dev/ttyUSB0")?;
+    let settings = serial::PortSettings {
+        baud_rate: serial::BaudRate::Baud115200,
+        char_size: serial::CharSize::Bits8,
+        parity: serial::Parity::ParityNone,
+        stop_bits: serial::StopBits::Stop1,
+        flow_control: serial::FlowControl::FlowNone,
+    };
+    port.configure(&settings)?;
+    port.set_timeout(Duration::from_secs(10))?;
+    let reader = dsmr5::Reader::new(port.bytes().take_while(|x| x.is_ok()).map(|x| x.unwrap()));
 
     for readout in reader {
         let telegram = readout.to_telegram().map_err(MyError::Dsmr5Error)?;


### PR DESCRIPTION
Thanks for creating this service @NULLx76 ! 

To use it in my setup, I wanted to run it in Docker, and I needed support for MQTT credentials. I've added all of that, and hereby offer it back upstream. You can use all of it or only parts of it. Up to you of course. 

This PR:
- Makes it work on Rust stable (thanks to @praseodym) 
- Adds support for credentials on MQTT
- Adds allow you to set the USB port in an env config
- Allows you to build everything as a docker file, for multiple platforms using `docker buildx`. 